### PR TITLE
Correct transform of exported nodes, change directory path

### DIFF
--- a/Exporter/Exporter.cs
+++ b/Exporter/Exporter.cs
@@ -139,6 +139,7 @@ namespace Godot
             Script script = null;
             Dictionary<string, object> scriptVariables = null;
 
+
             foreach(var cmp in components)
             {
                 Node node = null;
@@ -155,6 +156,8 @@ namespace Godot
                     {
                         dst.texture = Util.Cast<Texture>(ConvertUnityAsset(src.sprite));
                         rescale2d = src.sprite.pixelsPerUnit;
+                        dst.flipH = src.flipX;
+                        dst.flipV = src.flipY;
                     }
                 }
                 else if(cmp is Rigidbody2D)
@@ -248,21 +251,21 @@ namespace Godot
 
                 node2d.position = go.transform.localPosition * rescale2d;
                 node2d.position.y *= -1f;
-                // TODO Invert Y properly
-                // TODO Select pivot
-                //node2d.position.y = Screen.height - node2d.position.y;
+
 
                 node2d.scale = go.transform.localScale;
                 SpriteRenderer goSprite = go.GetComponent<SpriteRenderer>();
                 if(goSprite)
                 {
-                    if(goSprite.flipX) node2d.scale.x *= -1f;
-                    if(goSprite.flipY) node2d.scale.y *= -1f;
+                    // if(goSprite.flipX) node2d.scale.x *= -1f;
+                    // if(goSprite.flipY) node2d.scale.y *= -1f;
+                    node2d.zIndex = goSprite.sortingOrder;
                 }
 
                 node2d.rotation = -go.transform.localRotation.eulerAngles.z * Mathf.Deg2Rad;
 
                 node2d.visible = go.activeSelf;
+
 
                 rootNode = node2d;
             }
@@ -316,6 +319,8 @@ namespace Godot
 
             return rootNode;
         }
+
+
 
         NodeCategory DetectCategory(Component[] components)
         {
@@ -440,7 +445,8 @@ namespace Godot
             var at = new AtlasTexture();
             at.resourcePath = relPath;
             at.atlas = atlas;
-            at.region = sprite.textureRect;
+            // at.region = sprite.textureRect;
+            at.region = new Rect(0, 0, sprite.texture.width, sprite.texture.height);
 
             // Invert Y
             at.region.y = sprite.texture.height - at.region.y - at.region.height;

--- a/Exporter/Exporter.cs
+++ b/Exporter/Exporter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using UnityEditor;
@@ -12,7 +12,7 @@ namespace Godot
         [MenuItem("Godot/Export to Godot 3.1")]
         static void ExportToGodot31()
         {
-            var e = new Exporter("D:/PROJETS/INFO/UNITY/LD32_EatAndCopulate/GodotProject");
+            var e = new Exporter("Godot/GodotProject");
             e.Export();
         }
 
@@ -134,7 +134,7 @@ namespace Godot
 
             Node rootNode = null;
             Rigidbody2D promoteRigidBody2D = null;
-            float rescale2d = 1f;
+            float rescale2d = 100f;
             int scriptCount = 0;
             Script script = null;
             Dictionary<string, object> scriptVariables = null;
@@ -246,16 +246,21 @@ namespace Godot
                     }
                 }
 
-                node2d.position = go.transform.position * rescale2d;
+                node2d.position = go.transform.localPosition * rescale2d;
                 node2d.position.y *= -1f;
                 // TODO Invert Y properly
                 // TODO Select pivot
                 //node2d.position.y = Screen.height - node2d.position.y;
 
                 node2d.scale = go.transform.localScale;
+                SpriteRenderer goSprite = go.GetComponent<SpriteRenderer>();
+                if(goSprite)
+                {
+                    if(goSprite.flipX) node2d.scale.x *= -1f;
+                    if(goSprite.flipY) node2d.scale.y *= -1f;
+                }
 
-                // TODO Is eulerAngles in degrees or radians??
-                node2d.rotation = go.transform.rotation.eulerAngles.z;
+                node2d.rotation = -go.transform.localRotation.eulerAngles.z * Mathf.Deg2Rad;
 
                 node2d.visible = go.activeSelf;
 

--- a/Exporter/Nodes.cs
+++ b/Exporter/Nodes.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Godot
@@ -41,11 +41,17 @@ namespace Godot
         public Color selfModulate = Color.white;
         public bool visible = true;
 
+        public bool zRelative = true;
+        public int zIndex = 0;
+
         public override Dictionary<string, object> GetData()
         {
             var d = base.GetData();
             d.Add("self_modulate", selfModulate);
             d.Add("visible", visible);
+            d.Add("z_as_relative", zRelative);
+            d.Add("z_index", zIndex);
+
             return d;
         }
     }
@@ -69,14 +75,32 @@ namespace Godot
     class Sprite : Node2D
     {
         public Texture texture;
+        public bool flipH = false;
+        public bool flipV = false;
 
         public override Dictionary<string, object> GetData()
         {
             var d = base.GetData();
             d.Add("texture", texture);
+            d.Add("flip_h", flipH);
+            d.Add("flip_v", flipV);
             return d;
         }
     }
+
+
+    class ParallaxLayer : Node2D
+    {
+        public Vector2 motionScale = Vector2.one;
+
+        public override Dictionary<string, object> GetData()
+        {
+            var d = base.GetData();
+            d.Add("motion_scale", motionScale);
+            return d;
+        }
+    }
+
 
     class CollisionObject2D : Node2D
     { }

--- a/Exporter/Nodes.cs
+++ b/Exporter/Nodes.cs
@@ -36,6 +36,25 @@ namespace Godot
         }
     }
 
+
+
+    class CanvasLayer : Node
+    {
+        public int layer = 0;
+        public bool fwEnabled = true;
+        public float fwScale = 1.0f;
+        public override Dictionary<string, object> GetData()
+        {
+            var d = base.GetData();
+            d.Add("layer", layer);
+            d.Add("follow_viewport_enabled", fwEnabled);
+            d.Add("follow_viewport_scale", fwScale);
+            return d;
+        }
+
+    }
+
+
     class CanvasItem : Node
     {
         public Color selfModulate = Color.white;
@@ -55,6 +74,8 @@ namespace Godot
             return d;
         }
     }
+
+
 
     class Node2D : CanvasItem
     {

--- a/Exporter/Util.cs
+++ b/Exporter/Util.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 
@@ -8,6 +8,10 @@ namespace Godot
     {
         public static StreamWriter CreateStreamWriter(string path)
         {
+
+            // Create missing directories
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+
             // Godot expects files to be UTF-8, without BOM, and Unix line endings
             StreamWriter sw = new StreamWriter(path, false, new UTF8Encoding(false));
             sw.NewLine = "\n";

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 Unity Engine to Godot Engine exporter
 =======================================
 
-This is an experimental script that allows you to convert all scenes in your Unity project into a Godot project. It is not aimed at doing everything automatically, only things that can be converted decently.
-It's only a proof of concept on simple 2D games for now, and a ton of work remains to be done if it were to support everything else.
-While there are always cases where conversion is ambiguous and things to do manually, it's still fun to at least have the ability to automate this to some extent.
+This is a tool designed to convert 2D projects from Unity to Godot, based on [Zylann's unity_to_godot_converter](https://github.com/Zylann/unity_to_godot_converter).
 
-I have other projects to work on so I won't work much on this tool for now, and I am aware that there is an abysmal amount of features it could support^^ But feel free to hack around with it and improve it if you like the idea.
+I have just made some modifications to:
+
+1. Properly restore the position of sprites in the scene.
+2. Recreate the same parallax effect achieved in Unity by considering the sprite's z-axis position, utilizing CanvasLayer (see [Exporter.cs](https://github.com/pilorenzo/unity_to_godot_converter/blob/master/Exporter/Exporter.cs)).
+
+Tested on Godot 4.1.3 (only sprites and empty objects)
 
 
 How to install
@@ -14,39 +17,3 @@ How to install
 Copy this repository in your Unity project, inside a folder named `Editor`, and you should see a new `Godot` menu with options in it.
 
 Although it should not modify anything in the project, it's up to you to preserve your data if anything wrong happens :p
-
-
-Some challenges
------------------
-
-Here is a random list of things I had to take choices, for which workarounds may or may not exist.
-There may be a lot more, but you can get an idea of what this tool has to get through:
-
-- Unity only has `Camera`, but Godot has `Camera2D` and `Camera` for 3D. Choosing which one is ambiguous, so for now I create the 2D version of the camera is orthographic AND if a hint is enabled in the exporter for 2D projects. Also, in Unity, cameras also act as viewports, which is another separate node in Godot, so I'm not sure how to even convert those. Other components are ambiguous too, such as `Light`.
-
-- Godot has separate engines for 2D and 3D, but Unity only has 3D transforms with ortho camera. So the tool tries to guess what usage a GameObject is for by looking at its components. For example, if it has `SpriteRenderer`, or any of its children does, then the GameObject is converted to a `Node2D`. Otherwise, it becomes a `Spatial`. In some cases, it becomes a blank `Node` in cases where dimensions are irrelevant.
-
-- Unity uses components attached to GameObjects for its functionality, but Godot uses a node tree directly. That means a single GameObject with several components may convert into one node and several child nodes. If a GameObject only has a Transform and one component, a shortcut is taken to only produce a single Godot node, eliminating the unnecessary nesting.
-
-- Unity defines rigidbodies as components, but in Godot it is recommended to have such bodies as parent nodes because they control the position of their children, so instead of adding `RigidBodies` as a child nodes, they are have to be promoted as parent.
-
-- Unity can have multiple scripts on the same GameObject, but Godot can only have one per node. So the converter takes the first script it finds to the root node, and create children `Nodes` for each additional script. You may have to have a manual look after conversion if you use composition a lot.
-
-- Converting scripts is very complicated, so the tool rather creates stub scripts for each of them so it can still attach them to the proper final nodes, and attempts to preserve serialized variables. For example, when converting to GDScript, a C# script will be parsed for its variables which will be written as `export` on top of an empty GDScript, and the rest or the original source code is written as a big comment below them. This allows to keep configurations and keep track of what the script should be.
-
-- In Sprite texture resources, Unity allows to define a scaling between pixel coordinates and world coordinates, which is 100 by default, making sprites very small. Godot uses pixels as units at all times, so the plugin attempts to undo this scaling.
-
-- Unity can subdivide a 2D texture into sprites, so this almost always translates to Godot as `AtlasTextures`.
-
-- Unity uses a left-handed coordinate system, and in 2D its Y axis stays upwards. In Godot, the Y axis in 2D is downwards, so the tool attempts to invert positions (not working as best as it could at the moment)
-
-- Godot has no terrain system as of now, but a plugin exists for heightmaps which does not require recompilation. So the plugin could be packaged in the output project, and Unity terrains could be mostly converted to that format.
-
-- Things requiring a recompilation of Godot cannot be supported, for example the Admob module needs to be integrated into Godot manually by recompiling the engine.
-
-- Unity and Godot both support prefabs and nested prefabs, but I haven't worked in this part yet. On Unity side it should be a matter of using `PrefabUtility` to detect if a game object is actually an instance of a prefab, and it needs some research to see which delta-modifications are supported both by Unity and Godot.
-
-- As of 3.1 Godot only saves non-default values in scene data, but this tool can't afford to know them all, so scenes generated by it may be larger than if you had created them in Godot. Saving them from Godot might get rid of the redundancy.
-
-- Unity can imports 3D models as "fixed" prefabs, a bit like Godot does, so I am not sure if the tool should generate scenes for those, or let Godot do it
-


### PR DESCRIPTION
With this correction the transform of the nodes should be ok, even when the sprites are flipped.
I changed the output directory to "\<ProjectFolder\>/Godot/GodotProject".
Tested with a project with only sprites and empty objects